### PR TITLE
Properly scaling 2-bit colour to 8-bit colour

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,9 +132,9 @@ function animationFrame(now: number) {
       if (vsync) {
         break frameLoop;
       }
-      data[offset] = r << 6;
-      data[offset + 1] = g << 6;
-      data[offset + 2] = b << 6;
+      data[offset] = r * 85;
+      data[offset + 1] = g * 85;
+      data[offset + 2] = b * 85;
       data[offset + 3] = 0xff;
     }
     waitFor(() => getVGASignals().hsync);


### PR DESCRIPTION
### The Problem

- Scaling 2-bit colour into 8-bits just using `<< 6` is speedy, but, makes the video output look dull
- Theoretically speaking, it leads to a maximum brightness loss of ~25% 

### The Solution

- Instead of the `<< 6`, it is wiser to use `* 85` for proper usage of all 8-bits available
- The `85` is obtained by dividing the 8-bit value into four equidistant levels `[0, 85, 170, 255]`

### The Implementation

- The solution has been deployed on GitHub Pages and tested (https://sagardevachar.github.io/vga-playground/)
- The output video is vibrant and is closer to what a typical R-2R hardware would produce on a real display
- On observing the FPS of the simulator, we can notice ~6 FPS drop for a few presets (Stripes, Conway) indicating that there is a small impact on performance