### PR TITLE
Audio output

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,10 @@
     <main>
       <div id="code-editor"></div>
       <div id="vga-canvas-container">
-        <span id="fps-display">FPS: <span id="fps-count">00</span></span>
+        <div>
+          <span id="audio-latency-display">Audio latency: <span id="audio-latency-ms">00</span> ms </span>
+          <span id="fps-display">FPS: <span id="fps-count">00</span></span>
+        </div>
         <div id="input-values">
           ui_in:
           <button>0</button>

--- a/public/resampler.js
+++ b/public/resampler.js
@@ -33,6 +33,7 @@ class AudioResamplerProcessor extends AudioWorkletProcessor {
       for (let i = 0; i < samples.length; i++) {
         if ((this.writeIndex + 1) % this.ringBufferSize == this.readIndex)
         {
+          this.port.postMessage([this.ringBufferSize, 1.0]);
           console.log("Buffer is full. Dropping", samples.length - i, "incomming samples!");
           break; // Skip incomming samples when ring-buffer is full
         }
@@ -43,7 +44,7 @@ class AudioResamplerProcessor extends AudioWorkletProcessor {
       }
 
       const samplesAvailable = (this.writeIndex - this.readIndex + this.ringBufferSize) % this.ringBufferSize;
-      this.port.postMessage(samplesAvailable);
+      this.port.postMessage([samplesAvailable, samplesAvailable / this.ringBufferSize]);
     }
     else if (data.type === 'reset') {
       this.ringBuffer.fill(this.previousSample);

--- a/public/resampler.js
+++ b/public/resampler.js
@@ -41,6 +41,9 @@ class AudioResamplerProcessor extends AudioWorkletProcessor {
         this.ringBuffer[this.writeIndex] = samples[i];
         this.writeIndex = (this.writeIndex + 1) % this.ringBufferSize; // Wrap around
       }
+
+      const samplesAvailable = (this.writeIndex - this.readIndex + this.ringBufferSize) % this.ringBufferSize;
+      this.port.postMessage(samplesAvailable);
     }
     else if (data.type === 'reset') {
       this.ringBuffer.fill(this.previousSample);

--- a/public/resampler.js
+++ b/public/resampler.js
@@ -7,13 +7,16 @@ class AudioResamplerProcessor extends AudioWorkletProcessor {
     super();
     
     // Define buffer properties
-    this.ringBufferSize = 4096 * 4; // can store approximately 5 frames of audio data
+    this.downsampleFactor = 1;
+    this.ringBufferSize = 16_384 * this.downsampleFactor;    // stores approximately 5 frames of audio data at 192 kHz
     this.ringBuffer = new Float32Array(this.ringBufferSize); // ring-buffer helps to amortise uneven framerate and
                                                              // keeps re-sampler from starving or overflowing
     this.writeIndex = 0; // Index where new samples are written
     this.readIndex = 0;  // Index where samples are read
     this.previousSample = 0.0;
     this.ringBuffer.fill(this.previousSample);
+
+    this.downsampleBuffer = new Float32Array(128 * this.downsampleFactor);
     
     // Listen to messages from the main thread
     this.port.onmessage = this.handleMessage.bind(this);
@@ -29,6 +32,7 @@ class AudioResamplerProcessor extends AudioWorkletProcessor {
     // Handle incoming audio samples and write to the ring buffer
     if (data.type === 'samples') {
       this.currentFPS = data.fps;
+      this.downsampleFactor = data.downsampleFactor;
       const samples = data.samples;
       for (let i = 0; i < samples.length; i++) {
         if ((this.writeIndex + 1) % this.ringBufferSize == this.readIndex)
@@ -65,7 +69,7 @@ class AudioResamplerProcessor extends AudioWorkletProcessor {
 
     const playbackRate = this.currentFPS / this.expectedFPS;
     const borderSamples = 2;
-    const samplesRequired = Math.round(outputData.length * playbackRate) + borderSamples;
+    const samplesRequired = Math.round(outputData.length * playbackRate * this.downsampleFactor) + borderSamples;
 
     // example when samplesRequired = 8 + 2 border samples
     // (border samples are marked as 'b' below)
@@ -94,11 +98,14 @@ class AudioResamplerProcessor extends AudioWorkletProcessor {
 
     const samplesConsumed = Math.min(samplesRequired, samplesAvailable) - borderSamples;
 
+    if (this.downsampleBuffer.length != outputData.length * this.downsampleFactor);
+      this.downsampleBuffer = new Float32Array(outputData.length * this.downsampleFactor);
+
     // Calculate resampling ratio
-    const ratio = samplesConsumed / outputData.length;
+    const ratio = samplesConsumed / this.downsampleBuffer.length;
 
     // Fill the output buffer by resampling from the ring buffer
-    for (let i = 0; i < outputData.length; i++) {
+    for (let i = 0; i < this.downsampleBuffer.length; i++) {
       const floatPos = 0.5 + ratio * (i + 0.5); // use sample centroids, thus +0.5
       const intPos = Math.floor(floatPos);
       const nextIntPos = intPos + 1;
@@ -108,18 +115,34 @@ class AudioResamplerProcessor extends AudioWorkletProcessor {
         console.log(i, frac, intPos, nextIntPos, playbackRate, 'req: ', samplesRequired, 'avail: ', samplesAvailable, ratio, samplesConsumed);
 
       // Resample with linear interpolation
-      outputData[i] = this.interpolate(this.ringBuffer,
+      this.downsampleBuffer[i] = this.interpolate(this.ringBuffer,
         (this.readIndex + intPos) % this.ringBufferSize,
         (this.readIndex + nextIntPos) % this.ringBufferSize, frac);
     }
 
+    // Optional (if audio context does not support 192 kHz) downsample to output buffer
+    const N = this.downsampleFactor;
+    if (N > 1) {
+      for (let i = 0; i < outputData.length; i++) {
+        let acc = this.downsampleBuffer[i*N];
+        for (let j = 1; j < N; j++)
+          acc +=  this.downsampleBuffer[i*N + j];
+        outputData[i] = acc / N;
+      }
+    } else {
+      for (let i = 0; i < outputData.length; i++)
+         outputData[i] = this.downsampleBuffer[i];
+
+    }
+
+    // Store last sample as a future fallback value in case
+    // if data would not be ready for the next process() call
     this.previousSample = outputData[outputData.length - 1];
 
     // Update readIndex to match how many samples were consumed
     this.readIndex = (this.readIndex + samplesConsumed) % this.ringBufferSize;
 
-    // Return true to keep the processor alive
-    return true;
+    return true; // return true to keep the processor alive
   }
 }
 

--- a/public/resampler.js
+++ b/public/resampler.js
@@ -111,9 +111,6 @@ class AudioResamplerProcessor extends AudioWorkletProcessor {
       const nextIntPos = intPos + 1;
       const frac = floatPos - intPos; // fractional part for interpolation
 
-      if ((this.readIndex + nextIntPos) % this.ringBufferSize == this.writeIndex)
-        console.log(i, frac, intPos, nextIntPos, playbackRate, 'req: ', samplesRequired, 'avail: ', samplesAvailable, ratio, samplesConsumed);
-
       // Resample with linear interpolation
       this.downsampleBuffer[i] = this.interpolate(this.ringBuffer,
         (this.readIndex + intPos) % this.ringBufferSize,

--- a/public/resampler.js
+++ b/public/resampler.js
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024, Tiny Tapeout LTD
+// Author: Renaldas Zioma, Uri Shaked
+
+class AudioResamplerProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    
+    // Define buffer properties
+    this.ringBufferSize = 4096 * 4; // can store approximately 5 frames of audio data
+    this.ringBuffer = new Float32Array(this.ringBufferSize); // ring-buffer helps to amortise uneven framerate and
+                                                             // keeps re-sampler from starving or overflowing
+    this.writeIndex = 0; // Index where new samples are written
+    this.readIndex = 0;  // Index where samples are read
+    this.previousSample = 0.0;
+    this.ringBuffer.fill(this.previousSample);
+    
+    // Listen to messages from the main thread
+    this.port.onmessage = this.handleMessage.bind(this);
+
+    this.expectedFPS = 60.0;
+    this.currentFPS = this.expectedFPS;
+    console.log("Audio WebWorker started");
+  }
+
+  handleMessage(event) {
+    const data = event.data;
+
+    // Handle incoming audio samples and write to the ring buffer
+    if (data.type === 'samples') {
+      this.currentFPS = data.fps;
+      const samples = data.samples;
+      for (let i = 0; i < samples.length; i++) {
+        if ((this.writeIndex + 1) % this.ringBufferSize == this.readIndex)
+        {
+          console.log("Buffer is full. Dropping", samples.length - i, "incomming samples!");
+          break; // Skip incomming samples when ring-buffer is full
+        }
+        if (this.writeIndex == this.readIndex)
+          this.ringBuffer[(this.writeIndex - 1) % this.ringBufferSize] = samples[i]; 
+        this.ringBuffer[this.writeIndex] = samples[i];
+        this.writeIndex = (this.writeIndex + 1) % this.ringBufferSize; // Wrap around
+      }
+    }
+    else if (data.type === 'reset') {
+      this.ringBuffer.fill(this.previousSample);
+      this.readIndex = 0;
+      this.writeIndex = 0;
+    }
+  }
+
+  // Linear interpolation for resampling
+  interpolate(buffer, index1, index2, frac) {
+    return (1 - frac) * buffer[index1] + frac * buffer[index2];
+  }
+
+  // Process function that resamples the data from the ring buffer to match output size
+  process(inputs, outputs) {
+    const output = outputs[0]; // Mono output (1 channel)
+    const outputData = output[0]; // Get the output data array
+
+    const playbackRate = this.currentFPS / this.expectedFPS;
+    const borderSamples = 2;
+    const samplesRequired = Math.round(outputData.length * playbackRate) + borderSamples;
+
+    // example when samplesRequired = 8 + 2 border samples
+    // (border samples are marked as 'b' below)
+    // 
+    // 3 subsequent invocations of process():
+    //                                     
+    // ringBuffer:  b01234567b01234567b01234567b.
+    // process#0    ^........^                  | <- sampling window
+    // process#1             ^........^         | <- sampling window
+    // process#2                      ^........^| <- sampling window 
+    //                           WRITE pointer--`
+
+    // process#0    ^--READ pointer
+    // process#1             ^--READ pointer
+    // process#2                      ^--READ pointer 
+    // after process#2                         ^--READ pointer
+
+    const samplesAvailable = (this.writeIndex - this.readIndex + this.ringBufferSize) % this.ringBufferSize;
+    if (samplesAvailable < borderSamples)
+    {
+      for (let i = 0; i < outputData.length; i++)
+        outputData[i] = this.previousSample;
+      console.log("Buffer is empty. Using previous sample value " + this.previousSample.toFixed(3));
+      return true;
+    }
+
+    const samplesConsumed = Math.min(samplesRequired, samplesAvailable) - borderSamples;
+
+    // Calculate resampling ratio
+    const ratio = samplesConsumed / outputData.length;
+
+    // Fill the output buffer by resampling from the ring buffer
+    for (let i = 0; i < outputData.length; i++) {
+      const floatPos = 0.5 + ratio * (i + 0.5); // use sample centroids, thus +0.5
+      const intPos = Math.floor(floatPos);
+      const nextIntPos = intPos + 1;
+      const frac = floatPos - intPos; // fractional part for interpolation
+
+      if ((this.readIndex + nextIntPos) % this.ringBufferSize == this.writeIndex)
+        console.log(i, frac, intPos, nextIntPos, playbackRate, 'req: ', samplesRequired, 'avail: ', samplesAvailable, ratio, samplesConsumed);
+
+      // Resample with linear interpolation
+      outputData[i] = this.interpolate(this.ringBuffer,
+        (this.readIndex + intPos) % this.ringBufferSize,
+        (this.readIndex + nextIntPos) % this.ringBufferSize, frac);
+    }
+
+    this.previousSample = outputData[outputData.length - 1];
+
+    // Update readIndex to match how many samples were consumed
+    this.readIndex = (this.readIndex + samplesConsumed) % this.ringBufferSize;
+
+    // Return true to keep the processor alive
+    return true;
+  }
+}
+
+// Register the processor
+registerProcessor('resampler', AudioResamplerProcessor);
+

--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -37,9 +37,13 @@ export class AudioPlayer {
 
   readonly latencyInMilliseconds = 0.0;
   handleMessage(event) {
+    const getEffectiveLatency = (audioContext) => {
+      return audioContext.outputLatency || audioContext.baseLatency || 0;
+    }
+
     const samplesInBuffer = event.data[0];
     this.latencyInMilliseconds = samplesInBuffer / this.sampleRate * 1000.0;
-    this.latencyInMilliseconds += this.audioCtx.outputLatency * 1000.0;
+    this.latencyInMilliseconds += getEffectiveLatency(this.audioCtx) * 1000.0;
 
     const bufferOccupancy = event.data[1];
     if (this.resumeScheduled && bufferOccupancy > 0.25) // resume playback once resampler's

--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -13,10 +13,17 @@ export class AudioPlayer {
       this.resamplerNode = new AudioWorkletNode(this.audioCtx, 'resampler');
       this.resamplerNode.connect(this.audioCtx.destination);
 
+      this.resamplerNode.port.onmessage = this.handleMessage.bind(this);
+
       this.audioCtx.resume().then(() => {
         console.log('Audio playback started');
       });
     });
+  }
+
+  readonly latencyInMilliseconds = 0.0;
+  handleMessage(event) {
+    this.latencyInMilliseconds = event.data / this.sampleRate * 1000.0;
   }
 
   private writeIndex = 0;

--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -24,6 +24,7 @@ export class AudioPlayer {
   readonly latencyInMilliseconds = 0.0;
   handleMessage(event) {
     this.latencyInMilliseconds = event.data / this.sampleRate * 1000.0;
+    this.latencyInMilliseconds += this.audioCtx.outputLatency * 1000.0;
   }
 
   private writeIndex = 0;

--- a/src/FPSCounter.ts
+++ b/src/FPSCounter.ts
@@ -3,6 +3,7 @@ export class FPSCounter {
   private index = 0;
   private lastTime = -1;
   private pauseTime = -1;
+  readonly fps = 0;
 
   constructor() {}
 
@@ -18,6 +19,12 @@ export class FPSCounter {
       this.samples[this.index++ % this.samples.length] = time - this.lastTime;
     }
     this.lastTime = time;
+
+    if (this.index > 0) {
+      const slice = this.samples.slice(0, this.index);
+      const avgDelta = slice.reduce((a, b) => a + b, 0) / slice.length;
+      this.fps = 1000 / avgDelta;
+    }
   }
 
   pause(time: number) {
@@ -34,12 +41,6 @@ export class FPSCounter {
   }
 
   getFPS() {
-    if (this.index === 0) {
-      // Not enough data yet
-      return 0;
-    }
-    const slice = this.samples.slice(0, this.index);
-    const avgDelta = slice.reduce((a, b) => a + b, 0) / slice.length;
-    return 1000 / avgDelta;
+    return this.fps;
   }
 }

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -5,5 +5,6 @@ import { logo } from './logo';
 import { conway } from './conway';
 import { checkers } from './checkers';
 import { drop } from './drop';
+import { music } from './music';
 
-export const examples: Project[] = [stripes, balls, logo, conway, checkers, drop];
+export const examples: Project[] = [music, stripes, balls, logo, conway, checkers, drop];

--- a/src/examples/music/LICENSE.txt
+++ b/src/examples/music/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/examples/music/index.ts
+++ b/src/examples/music/index.ts
@@ -1,0 +1,12 @@
+import hvsync_generator_v from '../common/hvsync_generator.v?raw';
+import project_v from './project.v?raw';
+
+export const music = {
+  name: 'Music',
+  author: 'Renaldas Zioma',
+  topModule: 'tt_um_vga_example',
+  sources: {
+    'project.v': project_v,
+    'hvsync_generator.v': hvsync_generator_v,
+  },
+};

--- a/src/examples/music/project.v
+++ b/src/examples/music/project.v
@@ -5,6 +5,9 @@
 
 `default_nettype none
 
+`define MUSIC_SPEED   1'b1;  // for 60 FPS
+// `define MUSIC_SPEED   2'd2;  // for 30 FPS
+
 `define C1  481; // 32.70375 Hz 
 `define Cs1 454; // 34.6475 Hz 
 `define D1  429; // 36.7075 Hz 
@@ -198,7 +201,7 @@ module tt_um_vga_example(
     end else begin
 
       if (x == 0 && y == 0) begin
-        {frame_counter, frame_counter_frac} <= {frame_counter,frame_counter_frac} + 1;
+        {frame_counter, frame_counter_frac} <= {frame_counter,frame_counter_frac} + `MUSIC_SPEED;
       end
 
       // noise

--- a/src/examples/music/project.v
+++ b/src/examples/music/project.v
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2024 Renaldas Zioma, Erik Hemming
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+`default_nettype none
+
+`define C1  481; // 32.70375 Hz 
+`define Cs1 454; // 34.6475 Hz 
+`define D1  429; // 36.7075 Hz 
+`define Ds1 405; // 38.89125 Hz 
+`define E1  382; // 41.20375 Hz 
+`define F1  360; // 43.65375 Hz 
+`define Fs1 340; // 46.24875 Hz 
+`define G1  321; // 49.0 Hz 
+`define Gs1 303; // 51.9125 Hz 
+`define A1  286; // 55.0 Hz 
+`define As1 270; // 58.27 Hz 
+`define B1  255; // 61.735 Hz 
+`define C2  241; // 65.4075 Hz 
+`define Cs2 227; // 69.295 Hz 
+`define D2  214; // 73.415 Hz 
+`define Ds2 202; // 77.7825 Hz 
+`define E2  191; // 82.4075 Hz 
+`define F2  180; // 87.3075 Hz 
+`define Fs2 170; // 92.4975 Hz 
+`define G2  161; // 98.0 Hz 
+`define Gs2 152; // 103.825 Hz 
+`define A2  143; // 110.0 Hz 
+`define As2 135; // 116.54 Hz 
+`define B2  127; // 123.47 Hz 
+`define C3  120; // 130.815 Hz 
+`define Cs3 114; // 138.59 Hz 
+`define D3  107; // 146.83 Hz 
+`define Ds3 101; // 155.565 Hz 
+`define E3  95; // 164.815 Hz 
+`define F3  90; // 174.615 Hz 
+`define Fs3 85; // 184.995 Hz 
+`define G3  80; // 196.0 Hz 
+`define Gs3 76; // 207.65 Hz 
+`define A3  72; // 220.0 Hz 
+`define As3 68; // 233.08 Hz 
+`define B3  64; // 246.94 Hz 
+`define C4  60; // 261.63 Hz 
+`define Cs4 57; // 277.18 Hz 
+`define D4  54; // 293.66 Hz 
+`define Ds4 51; // 311.13 Hz 
+`define E4  48; // 329.63 Hz 
+`define F4  45; // 349.23 Hz 
+`define Fs4 43; // 369.99 Hz 
+`define G4  40; // 392.0 Hz 
+`define Gs4 38; // 415.3 Hz 
+`define A4  36; // 440.0 Hz 
+`define As4 34; // 466.16 Hz 
+`define B4  32; // 493.88 Hz 
+`define C5  30; // 523.26 Hz 
+`define Cs5 28; // 554.36 Hz 
+`define D5  27; // 587.32 Hz 
+`define Ds5 25; // 622.26 Hz 
+`define E5  24; // 659.26 Hz 
+`define F5  23; // 698.46 Hz 
+`define Fs5 21; // 739.98 Hz 
+`define G5  20; // 784.0 Hz 
+`define Gs5 19; // 830.6 Hz 
+`define A5  18; // 880.0 Hz 
+`define As5 17; // 932.32 Hz 
+`define B5  16; // 987.76 Hz 
+
+module tt_um_vga_example(
+  input  wire [7:0] ui_in,    // Dedicated inputs
+  output wire [7:0] uo_out,   // Dedicated outputs
+  input  wire [7:0] uio_in,   // IOs: Input path
+  output wire [7:0] uio_out,  // IOs: Output path
+  output wire [7:0] uio_oe,   // IOs: Enable path (active high: 0=input, 1=output)
+  input  wire       ena,      // always 1 when the design is powered, so you can ignore it
+  input  wire       clk,      // clock
+  input  wire       rst_n     // reset_n - low to reset
+);
+
+  // VGA signals
+  wire hsync;
+  wire vsync;
+  wire [1:0] R;
+  wire [1:0] G;
+  wire [1:0] B;
+  wire video_active;
+  wire [9:0] x;
+  wire [9:0] y;
+  wire sound;
+
+  // TinyVGA PMOD
+  assign {R,G,B} = {6{video_active * sound}};
+  assign uo_out = {hsync, B[0], G[0], R[0], vsync, B[1], G[1], R[1]};
+  assign uio_out = {sound, 7'b0};
+
+  // Unused outputs assigned to 0.
+  assign uio_oe  = 8'hff;
+
+  // Suppress unused signals warning
+  wire _unused_ok = &{ena, ui_in, uio_in};
+
+  hvsync_generator hvsync_gen(
+    .clk(clk),
+    .reset(~rst_n),
+    .hsync(hsync),
+    .vsync(vsync),
+    .display_on(video_active),
+    .hpos(x),
+    .vpos(y)
+  );
+    
+  // reg [19:0] lfsr; 
+  // wire feedback = lfsr[19] ^ lfsr[15] ^ lfsr[11] ^ lfsr[5] ^ lfsr[4] ^ lfsr[3] + 1;
+  reg [12:0] lfsr;
+  wire feedback = lfsr[12] ^ lfsr[8] ^ lfsr[2] ^ lfsr[0] + 1;
+  always @(posedge clk) begin
+    lfsr <= {lfsr[11:0], feedback};
+  end
+
+  // music
+  wire [2:0] part = frame_counter[9-:3];
+  wire [12:0] timer = {frame_counter, frame_counter_frac};
+  reg noise, noise_src = ^lfsr;
+  reg [2:0] noise_counter;
+
+  wire square60hz =  y < 262;                 // 60Hz square wave
+  wire square120hz = y[7];                    // 120Hz square wave
+  wire square240hz = y[6];                    // 240Hz square wave
+  wire square480hz = y[5];                    // 480Hz square wave
+  wire [4:0] envelopeA = 5'd31 - timer[4:0];  // exp(t*-10) decays to 0 approximately in 32 frames  [255 215 181 153 129 109  92  77  65  55  46  39  33  28  23  20  16  14 12  10   8   7   6   5   4   3   3   2   2]
+  wire [4:0] envelopeB = 5'd31 - timer[3:0]*2;// exp(t*-20) decays to 0 approximately in 16 frames  [255 181 129  92  65  46  33  23  16  12   8   6   4   3]
+  wire       envelopeP8 = (|timer[3:2])*5'd31;// pulse for 8 frames
+  wire beats_1_3 = timer[5:4] == 2'b10;
+
+  // melody notes (in hsync): 151  26  40  60 _ 90 143  23  35
+  // (x1.5 wrap-around progression)
+  reg [8:0] note2_freq;
+  reg [8:0] note2_counter;
+  reg       note2;
+
+  reg [7:0] note_freq;
+  reg [7:0] note_counter;
+  reg       note;
+  wire [3:0] note_in = timer[7-:4];           // 8 notes, 32 frames per note each. 256 frames total, ~4 seconds
+  always @(note_in)
+  case(note_in)
+      4'd0 : note_freq = `E2
+      4'd1 : note_freq = `E3
+      4'd2 : note_freq = `D3
+      4'd3 : note_freq = `E3
+      4'd4 : note_freq = `A2
+      4'd5 : note_freq = `B2
+      4'd6 : note_freq = `D3
+      4'd7 : note_freq = `E3
+      4'd8 : note_freq = `E2
+      4'd9 : note_freq = `E3
+      4'd10: note_freq = `D3
+      4'd11: note_freq = `E3
+      4'd12: note_freq = `G2
+      4'd13: note_freq = `E3
+      4'd14: note_freq = `Fs2
+      4'd15: note_freq = `E3
+  endcase
+
+  wire [2:0] note2_in = timer[8-:3];           // 8 notes, 32 frames per note each. 256 frames total, ~4 seconds
+  always @(note2_in)
+  case(note2_in)
+      3'd0 : note2_freq = `B1
+      3'd1 : note2_freq = `A2
+      3'd2 : note2_freq = `E1
+      3'd3 : note2_freq = `A2
+      3'd4 : note2_freq = `B1
+      3'd5 : note2_freq = `A2
+      3'd6 : note2_freq = `D1
+      3'd7 : note2_freq = `Cs1
+  endcase
+
+  // wire kick   = square60hz & (~|x[7:5] & x[4:0] < envelopeA);                 // 60Hz square wave with half second envelope
+  wire kick   = square60hz & (x < envelopeA*4);                 // 60Hz square wave with half second envelope
+  wire snare  = noise      & (x >= 128 && x < 128+envelopeB*4);   // noise with half second envelope
+  wire lead   = note       & (x >= 256 && x < 256+envelopeB*8);   // ROM square wave with quarter second envelope
+  wire base   = note2      & (x >= 512 && x < ((beats_1_3)?(512+8*4):(512+32*4)));  
+  assign sound = { kick | (snare & beats_1_3 & part != 0) | (base) | (lead & part > 2) };
+
+  reg [11:0] frame_counter;
+  reg frame_counter_frac;
+  always @(posedge clk) begin
+    if (~rst_n) begin
+      frame_counter <= 0;
+      frame_counter_frac <= 0;
+      noise_counter <= 0;
+      note_counter <= 0;
+      note2_counter <= 0;
+      noise <= 0;
+      note <= 0;
+      note2 <= 0;
+
+    end else begin
+
+      if (x == 0 && y == 0) begin
+        {frame_counter, frame_counter_frac} <= {frame_counter,frame_counter_frac} + 1;
+      end
+
+      // noise
+      if (x == 0) begin
+        if (noise_counter > 1) begin 
+          noise_counter <= 0;
+          noise <= noise ^ noise_src;
+        end else
+          noise_counter <= noise_counter + 1'b1;
+      end
+
+      // square wave
+      if (x == 0) begin
+        if (note_counter > note_freq) begin
+          note_counter <= 0;
+          note <= ~note;
+        end else begin
+          note_counter <= note_counter + 1'b1;
+        end
+
+        if (note2_counter > note2_freq) begin
+          note2_counter <= 0;
+          note2 <= ~note2;
+        end else begin
+          note2_counter <= note2_counter + 1'b1;
+        end
+      end
+    end
+  end
+
+endmodule

--- a/src/examples/stripes/project.v
+++ b/src/examples/stripes/project.v
@@ -29,19 +29,13 @@ module tt_um_vga_example(
 
   // TinyVGA PMOD
   assign uo_out = {hsync, B[0], G[0], R[0], vsync, B[1], G[1], R[1]};
-  assign uio_out = {sound, 7'b0};
 
   // Unused outputs assigned to 0.
-  assign uio_oe  = 8'hff;
+  assign uio_out = 0;
+  assign uio_oe  = 0;
 
   // Suppress unused signals warning
   wire _unused_ok = &{ena, ui_in, uio_in};
-
-  reg [15:0] counter2;
-  assign sound = counter2[14];  
-  always @(posedge clk) begin
-    counter2 <= counter2 + 1;
-  end
 
   reg [9:0] counter;
 

--- a/src/index.css
+++ b/src/index.css
@@ -39,6 +39,14 @@ main {
   max-width: 50%;
 }
 
+#audio-latency-display {
+  position: absolute;
+  top: 8px;
+  right: 80px;
+  font-variant-numeric: tabular-nums;
+  color: grey;
+}
+
 #fps-display {
   position: absolute;
   top: 8px;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ let jmod = new HDLModuleWASM(res.output.modules['TOP'], res.output.modules['@CON
 //let jmod = new HDLModuleJS(res.output.modules['TOP'], res.output.modules['@CONST-POOL@']);
 await jmod.init();
 
+const uo_out_offset_in_jmod_databuf = jmod.globals.lookup("uo_out").offset;
+
 function reset() {
   const ui_in = jmod.state.ui_in;
   jmod.powercycle();
@@ -44,7 +46,11 @@ function reset() {
 reset();
 
 function getVGASignals() {
-  const uo_out = jmod.state.uo_out as number;
+  // it is significanly faster to read 'uo_out' value directly from the jmod data buffer
+  // instead of jmod.state.uo_out acccessor property
+  // see HDLModuleWASM.defineProperty() implementation for inner details on how accessor works
+  const uo_out = jmod.data8[uo_out_offset_in_jmod_databuf];
+
   return {
     hsync: !!(uo_out & 0b10000000),
     vsync: !!(uo_out & 0b00001000),

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,9 +73,7 @@ function getAudioSignal() {
 }
 
 const expectedFPS = 60;
-const sampleRate = 48_000*4;// @TODO: 192000 high sampleRate might not be supported on all platforms
-                            // downsample to 48000 inside the AudioResamplerProcessor
-                            // Empirically higher sampling rate helps with occasional high pitch noise.
+const sampleRate = 192_000; // 192 kHz -- higher number gives a better quality
 const audioPlayer = new AudioPlayer(sampleRate, expectedFPS, () => {
   if (audioPlayer.isRunning())
     inputButtons[audioButtonIndex].classList.add('active');
@@ -84,10 +82,10 @@ const audioPlayer = new AudioPlayer(sampleRate, expectedFPS, () => {
 });
 let enableAudioUpdate = audioPlayer.needsFeeding();
 
-const vgaClockRate = 25_175_000;
+const vgaClockRate = 25_175_000; // 25.175 MHz -- VGA pixel clock
 const ticksPerSample = vgaClockRate / sampleRate;
 
-const lowPassFrequency = 20_000;
+const lowPassFrequency = 20_000; // 20 kHz -- Audio PMOD low pass filter
 const lowPassFilterSize = Math.ceil(sampleRate/lowPassFrequency);
 
 let audioTickCounter = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,7 @@ const canvas = document.querySelector<HTMLCanvasElement>('#vga-canvas');
 const ctx = canvas?.getContext('2d');
 const imageData = ctx?.createImageData(736, 520);
 const fpsDisplay = document.querySelector('#fps-count');
+const audioLatencyDisplay = document.querySelector('#audio-latency-ms');
 
 function waitFor(condition: () => boolean, timeout = 10000) {
   let counter = 0;
@@ -166,6 +167,10 @@ function animationFrame(now: number) {
 
   if (fpsDisplay) {
     fpsDisplay.textContent = `${fpsCounter.getFPS().toFixed(0)}`;
+  }
+
+  if (audioLatencyDisplay) {
+    audioLatencyDisplay.textContent = `${audioPlayer.latencyInMilliseconds.toFixed(0)}`
   }
 
   if (stopped || !imageData || !ctx) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,7 @@ document.querySelector('#download-button')?.addEventListener('click', () => {
 });
 
 function toggleButton(index: number) {
-  if (index === 8) {
+  if (index === audioButtonIndex) {
     if (audioPlayer.isRunning())
       audioPlayer.suspend();
     else


### PR DESCRIPTION
Implemented WebWorker to resample output audio according to difference between browser FPS and expected (60) frame rate of VGA output from Verilator.

New audio pipeline:
1) first generated audio samples are low-pass filtered (20 kHz) to approximately simulate Audio PMOD behavior and reduce occasional high-pitch noise especially when browser FPS significantly differs from 60 Hz
2) filtered samples are accumulated in the ring-buffer (approximately 5 frames for data) of audio Web Worker running on a separate thread. Ring-buffer helps to amortise uneven framerate and keeps worker thread from starving or overflowing.
3) finally, audio Web Worker thread is responsible for resampling available audio data so that it is stretched or compressed to match the sampling rate of the audio driver.