### PR TITLE
Distinct, cleaned-up and fixed (hopefully) gaming PMOD verilog

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,22 @@
           <button>5</button>
           <button>6</button>
           <button>7</button>
-          <button>Audio</button>
+          <button data-role="audio">Audio</button>
+          <button data-role="gaming">Gaming</button>
+        </div>
+        <div id="gaming-pmod-inputs" style="display: none">
+          <button data-index="6">⬅️</button>
+          <button data-index="7">➡️</button>
+          <button data-index="4">⬆️</button>
+          <button data-index="5">⬇️</button>
+          <button data-index="8">🅰️</button>
+          <button data-index="0">🅱️</button>
+          <button data-index="9">X</button>
+          <button data-index="1">Y</button>
+          <button data-index="2">Select</button>
+          <button data-index="3">Start</button>
+          <button data-index="10">L</button>
+          <button data-index="11">R</button>
         </div>
         <canvas width="736" height="520" id="vga-canvas"></canvas>
       </div>

--- a/src/examples/gaming/LICENSE.txt
+++ b/src/examples/gaming/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/examples/gaming/gaming_pmod.v
+++ b/src/examples/gaming/gaming_pmod.v
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2025 Pat Deegan
+ * https://psychogenic.com
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+`default_nettype none
+
+
+/*
+ * game_controller: An individual controller, holding the buttons state
+ * as interpreted based on the input data_reg.
+ *
+  * a not-present/disconnected controller will have 
+ * is_present == 0, and all buttons will return as 0.
+*/
+module game_controller (
+    input wire [11:0] data_reg,
+    output wire b,
+    output wire y,
+    output wire select,
+    output wire start,
+    output wire up,
+    output wire down,
+    output wire left,
+    output wire right,
+    output wire a,
+    output wire x,
+    output wire l,
+    output wire r,
+    output wire is_present
+);
+  // if the data is all 1's, this indicates a 
+  // disconnected controller
+  // In that case, is_present will be 0, as will all the button
+  // states returned
+  wire reg_empty;
+  assign reg_empty = (data_reg == 12'hfff);
+  assign is_present = reg_empty ? 0 : 1'b1;
+  assign {b, y, select, start, up, down, left, right, a, x, l, r} = reg_empty ? 0 : data_reg;
+
+endmodule
+
+/*
+ * game_controller_pmod_driver: understands the protocol
+ * received from the 3 pins on the PMOD (pmod_*)
+ * This protocol returns state for 2 controllers, so 
+ * 24 bits of data.
+*/
+module game_controller_pmod_driver #(
+    parameter BIT_WIDTH = 24
+) (
+    input wire rst_n,
+    input wire clk,
+    input wire pmod_data,
+    input wire pmod_clk,
+    input wire pmod_latch,
+    output reg [BIT_WIDTH-1:0] data_reg
+);
+
+  reg pmod_clk_prev;
+  reg pmod_latch_prev;
+  reg [BIT_WIDTH-1:0] shift_reg;
+
+  // sync pmod signals to the clk domain:
+  reg [1:0] pmod_data_sync;
+  reg [1:0] pmod_clk_sync;
+  reg [1:0] pmod_latch_sync;
+
+  always @(posedge clk) begin
+    if (~rst_n) begin
+      pmod_data_sync  <= 2'b0;
+      pmod_clk_sync   <= 2'b0;
+      pmod_latch_sync <= 2'b0;
+    end else begin
+      pmod_data_sync  <= {pmod_data_sync[0], pmod_data};
+      pmod_clk_sync   <= {pmod_clk_sync[0], pmod_clk};
+      pmod_latch_sync <= {pmod_latch_sync[0], pmod_latch};
+    end
+  end
+
+  // shift register for the pmod data
+  always @(posedge clk) begin
+    if (~rst_n) begin
+      shift_reg <= 0;
+      data_reg <= 0;
+      pmod_clk_prev <= 1'b0;
+      pmod_latch_prev <= 1'b0;
+    end
+    begin
+      pmod_clk_prev   <= pmod_clk_sync[1];
+      pmod_latch_prev <= pmod_latch_sync[1];
+
+      if (pmod_latch_sync[1] & ~pmod_latch_prev) begin
+        // just went up, latch that data
+        data_reg <= shift_reg;
+      end
+      if (~pmod_clk_sync[1] & pmod_clk_prev) begin
+        // just went down, put the last data bit on the end
+        // of the shift register
+        shift_reg <= {shift_reg[BIT_WIDTH-2:0], pmod_data_sync[1]};
+      end
+    end
+  end
+
+endmodule
+
+
+/*
+ * game_controller_pmod -- main interface to the PMOD.
+ * provides data for two controllers, through the various
+ * state arrays below (start[1:0], up[1:0], etc.)
+ * All the values for the first controller are at index 0
+ * (up[0], y[0], etc) and for the second, at index 1.
+ *
+ * In addition to the button states, it provides an 
+ * is_present array, to let you know if the given 
+ * controller is actually connected (e.g. is_present[1] == 0
+ * indicates that there's no second controller connected).
+ *
+ * Feed it the 3 wires coming in from the PMOD, 
+ * pmod_data, pmod_clk, and pmod_latch, and then 
+ * enjoy all the button presses.
+*/
+module game_controller_pmod (
+    input wire rst_n,
+    input wire clk,
+    input wire pmod_data,
+    input wire pmod_clk,
+    input wire pmod_latch,
+    
+    
+    output wire [1:0] b,
+    output wire [1:0] y,
+    output wire [1:0] select,
+    output wire [1:0] start,
+    output wire [1:0] up,
+    output wire [1:0] down,
+    output wire [1:0] left,
+    output wire [1:0] right,
+    output wire [1:0] a,
+    output wire [1:0] x,
+    output wire [1:0] l,
+    output wire [1:0] r,
+    output wire [1:0] is_present
+
+);
+
+  // game_controller_pmod_data -- holds the 
+  // all the bits for both controllers, latched
+  // from the pmod
+  wire [23:0] game_controller_pmod_data;
+  
+  // the driver interprets the protocol 
+  // and sets the contents of game_controller_pmod_data
+  game_controller_pmod_driver driver (
+    .rst_n(rst_n),
+    .clk(clk),
+    .pmod_data(pmod_data),
+    .pmod_clk(pmod_clk),
+    .pmod_latch(pmod_latch),
+    .data_reg(game_controller_pmod_data)
+  );
+  
+  // 2 game_controllers decode their respective 
+  // data blobs into the up/down/left/right/a/x...
+  // states
+  game_controller decoder1 (
+    .data_reg(game_controller_pmod_data[11:0]),
+    .b(b[0]),
+    .y(y[0]),
+    .select(select[0]),
+    .start(start[0]),
+    .up(up[0]),
+    .down(down[0]),
+    .left(left[0]),
+    .right(right[0]),
+    .a(a[0]),
+    .x(x[0]),
+    .l(l[0]),
+    .r(r[0]),
+    .is_present(is_present[0])
+  );
+  
+  
+  game_controller decoder2 (
+    .data_reg(game_controller_pmod_data[23:12]),
+    .b(b[1]),
+    .y(y[1]),
+    .select(select[1]),
+    .start(start[1]),
+    .up(up[1]),
+    .down(down[1]),
+    .left(left[1]),
+    .right(right[1]),
+    .a(a[1]),
+    .x(x[1]),
+    .l(l[1]),
+    .r(r[1]),
+    .is_present(is_present[1])
+  );
+  
+
+endmodule
+

--- a/src/examples/gaming/index.ts
+++ b/src/examples/gaming/index.ts
@@ -1,0 +1,12 @@
+import hvsync_generator_v from '../common/hvsync_generator.v?raw';
+import project_v from './project.v?raw';
+
+export const gaming = {
+  name: 'Gaming',
+  author: 'Uri Shaked',
+  topModule: 'tt_um_gaming_pmod_demo',
+  sources: {
+    'project.v': project_v,
+    'hvsync_generator.v': hvsync_generator_v,
+  },
+};

--- a/src/examples/gaming/project.v
+++ b/src/examples/gaming/project.v
@@ -7,7 +7,11 @@
 
 `default_nettype none
 
-module tt_um_gaming_pmod_demo(
+module tt_um_gaming_pmod_demo #(
+  parameter UI_IN_INDEX_LATCH = 3,
+  parameter UI_IN_INDEX_CLOCK = 4,
+  parameter UI_IN_INDEX_DATA  = 5
+) (
   input  wire [7:0] ui_in,    // Dedicated inputs
   output wire [7:0] uo_out,   // Dedicated outputs
   input  wire [7:0] uio_in,   // IOs: Input path
@@ -31,29 +35,34 @@ module tt_um_gaming_pmod_demo(
   // TinyVGA PMOD
   assign uo_out  = {hsync, B[0], G[0], R[0], vsync, B[1], G[1], R[1]};
 
-  // Game controller
-  wire [11:0] game_controller_pmod_data;
-  wire inp_b;
-  wire inp_y;
-  wire inp_select;
-  wire inp_start;
-  wire inp_up;
-  wire inp_down;
-  wire inp_left;
-  wire inp_right;
-  wire inp_a;
-  wire inp_x;
-  wire inp_l;
-  wire inp_r;
+  // Game controller buttons state
+  // controller 0 has the 0th bit of each of these,
+  // e.g. if up button is pressed inp_up[0] will be 1 
+  // for controller 0
+  // the second controller would stick that state in inp_up[1]
+  // See the gaming_pmod.v file comments for more deets.
+  wire [1:0] inp_b;
+  wire [1:0] inp_y;
+  wire [1:0] inp_select;
+  wire [1:0] inp_start;
+  wire [1:0] inp_up;
+  wire [1:0] inp_down;
+  wire [1:0] inp_left;
+  wire [1:0] inp_right;
+  wire [1:0] inp_a;
+  wire [1:0] inp_x;
+  wire [1:0] inp_l;
+  wire [1:0] inp_r;
+  wire [1:0] controller_present;
+  
 
-  wire left_stripe = inp_left && pix_x < 50;
-  wire right_stripe = inp_right && pix_x >= 50 && pix_x < 100;
-  wire up_stripe = inp_up && pix_x >= 100 && pix_x < 150;
-  wire down_stripe = inp_down && pix_x >= 150 && pix_x < 200;
-  wire a_stripe = inp_a && pix_x >= 200 && pix_x < 250;
-  wire b_stripe = inp_b && pix_x >= 250 && pix_x < 300;
-
-
+  wire [1:0] left_stripe = pix_x < 50 ? inp_left : 0;
+  wire [1:0] right_stripe = pix_x >= 50 && pix_x < 100 ? inp_right : 0 ;
+  wire [1:0] up_stripe = (pix_x >= 100 && pix_x < 150 ) ? inp_up : 0;
+  wire [1:0] down_stripe = (pix_x >= 150 && pix_x < 200) ? inp_down : 0;
+  wire [1:0] a_stripe = (pix_x >= 200 && pix_x < 250) ? inp_a : 0;
+  wire [1:0] b_stripe = (pix_x >= 250 && pix_x < 300) ? inp_b : 0;
+  
   hvsync_generator vga_sync_gen (
     .clk(clk),
     .reset(~rst_n),
@@ -63,18 +72,18 @@ module tt_um_gaming_pmod_demo(
     .hpos(pix_x),
     .vpos(pix_y)
   );
-
-  game_controller_pmod_driver driver (
+  
+  
+  game_controller_pmod game_con_pmod(
     .rst_n(rst_n),
     .clk(clk),
-    .pmod_data(ui_in[6]),
-    .pmod_clk(ui_in[5]),
-    .pmod_latch(ui_in[4]),
-    .data_reg(game_controller_pmod_data)
-  );
+    
+    // pmod input pins
+    .pmod_latch(ui_in[UI_IN_INDEX_LATCH]),
+    .pmod_clk(ui_in[UI_IN_INDEX_CLOCK]),
+    .pmod_data(ui_in[UI_IN_INDEX_DATA]),
 
-  game_controller_pmod_decoder decoder (
-    .data_reg(game_controller_pmod_data),
+    // output state for both controllers
     .b(inp_b),
     .y(inp_y),
     .select(inp_select),
@@ -86,98 +95,26 @@ module tt_um_gaming_pmod_demo(
     .a(inp_a),
     .x(inp_x),
     .l(inp_l),
-    .r(inp_r)
+    .r(inp_r),
+    .is_present(controller_present)
+    
   );
+
 
   // RGB output logic
   always @(posedge clk) begin
-    if (~rst_n) begin
+    if (~rst_n || ~video_active) begin
       R <= 0;
       G <= 0;
       B <= 0;
     end else begin
-      R <= video_active && (left_stripe || down_stripe || b_stripe) ? 2'b11 : 0;
-      G <= video_active && (right_stripe || down_stripe || a_stripe) ? 2'b11 : 0;
-      B <= video_active && (up_stripe || a_stripe || b_stripe) ? 2'b11 : 0;
+      R <= (left_stripe | down_stripe | b_stripe);
+      G <= (right_stripe | down_stripe | a_stripe);
+      B <= (up_stripe | a_stripe | b_stripe);
     end
   end
 
 endmodule
 
 
-module game_controller_pmod_decoder (
-    input wire [11:0] data_reg,
-    output wire b,
-    output wire y,
-    output wire select,
-    output wire start,
-    output wire up,
-    output wire down,
-    output wire left,
-    output wire right,
-    output wire a,
-    output wire x,
-    output wire l,
-    output wire r
-);
 
-  // SNES controller mapping (12 bits):
-  assign {b, y, select, start, up, down, left, right, a, x, l, r} = data_reg;
-
-endmodule
-
-
-module game_controller_pmod_driver #(
-    parameter BIT_WIDTH = 12
-) (
-    input wire rst_n,
-    input wire clk,
-    input wire pmod_data,
-    input wire pmod_clk,
-    input wire pmod_latch,
-    output reg [BIT_WIDTH-1:0] data_reg
-);
-
-  reg pmod_clk_prev;
-  reg pmod_latch_prev;
-  reg [BIT_WIDTH-1:0] shift_reg;
-
-  // sync pmod signals to the clk domain:
-  reg [1:0] pmod_data_sync;
-  reg [1:0] pmod_clk_sync;
-  reg [1:0] pmod_latch_sync;
-
-  always @(posedge clk) begin
-    if (~rst_n) begin
-      pmod_data_sync  <= 2'b0;
-      pmod_clk_sync   <= 2'b0;
-      pmod_latch_sync <= 2'b0;
-    end else begin
-      pmod_data_sync  <= {pmod_data_sync[0], pmod_data};
-      pmod_clk_sync   <= {pmod_clk_sync[0], pmod_clk};
-      pmod_latch_sync <= {pmod_latch_sync[0], pmod_latch};
-    end
-  end
-
-  // shift register for the pmod data
-  always @(posedge clk) begin
-    if (~rst_n) begin
-      shift_reg <= 0;
-      data_reg <= 0;
-      pmod_clk_prev <= 1'b0;
-      pmod_latch_prev <= 1'b0;
-    end
-    begin
-      pmod_clk_prev   <= pmod_clk_sync[1];
-      pmod_latch_prev <= pmod_latch_sync[1];
-
-      if (pmod_latch_prev & ~pmod_latch_sync[1]) begin
-        data_reg <= shift_reg;
-      end
-      if (pmod_clk_prev & ~pmod_clk_sync[1]) begin
-        shift_reg <= {shift_reg[BIT_WIDTH-2:0], pmod_data_sync[1]};
-      end
-    end
-  end
-
-endmodule

--- a/src/examples/gaming/project.v
+++ b/src/examples/gaming/project.v
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2024 Ciro Cattuto
+ * based on the VGA examples by Uri Shaked
+ * and on tt07-conway-term (https://github.com/ccattuto/tt07-conway-term)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+`default_nettype none
+
+module tt_um_gaming_pmod_demo(
+  input  wire [7:0] ui_in,    // Dedicated inputs
+  output wire [7:0] uo_out,   // Dedicated outputs
+  input  wire [7:0] uio_in,   // IOs: Input path
+  output wire [7:0] uio_out,  // IOs: Output path
+  output wire [7:0] uio_oe,   // IOs: Enable path (active high: 0=input, 1=output)
+  input  wire       ena,      // always 1 when the design is powered, so you can ignore it
+  input  wire       clk,      // clock
+  input  wire       rst_n     // reset_n - low to reset
+);
+
+  // VGA signals
+  wire hsync;
+  wire vsync;
+  reg [1:0] R;
+  reg [1:0] G;
+  reg [1:0] B;
+  wire video_active;
+  wire [9:0] pix_x;
+  wire [9:0] pix_y;
+
+  // TinyVGA PMOD
+  assign uo_out  = {hsync, B[0], G[0], R[0], vsync, B[1], G[1], R[1]};
+
+  // Game controller
+  wire [11:0] game_controller_pmod_data;
+  wire inp_b;
+  wire inp_y;
+  wire inp_select;
+  wire inp_start;
+  wire inp_up;
+  wire inp_down;
+  wire inp_left;
+  wire inp_right;
+  wire inp_a;
+  wire inp_x;
+  wire inp_l;
+  wire inp_r;
+
+  wire left_stripe = inp_left && pix_x < 50;
+  wire right_stripe = inp_right && pix_x >= 50 && pix_x < 100;
+  wire up_stripe = inp_up && pix_x >= 100 && pix_x < 150;
+  wire down_stripe = inp_down && pix_x >= 150 && pix_x < 200;
+  wire a_stripe = inp_a && pix_x >= 200 && pix_x < 250;
+  wire b_stripe = inp_b && pix_x >= 250 && pix_x < 300;
+
+
+  hvsync_generator vga_sync_gen (
+    .clk(clk),
+    .reset(~rst_n),
+    .hsync(hsync),
+    .vsync(vsync),
+    .display_on(video_active),
+    .hpos(pix_x),
+    .vpos(pix_y)
+  );
+
+  game_controller_pmod_driver driver (
+    .rst_n(rst_n),
+    .clk(clk),
+    .pmod_data(ui_in[6]),
+    .pmod_clk(ui_in[5]),
+    .pmod_latch(ui_in[4]),
+    .data_reg(game_controller_pmod_data)
+  );
+
+  game_controller_pmod_decoder decoder (
+    .data_reg(game_controller_pmod_data),
+    .b(inp_b),
+    .y(inp_y),
+    .select(inp_select),
+    .start(inp_start),
+    .up(inp_up),
+    .down(inp_down),
+    .left(inp_left),
+    .right(inp_right),
+    .a(inp_a),
+    .x(inp_x),
+    .l(inp_l),
+    .r(inp_r)
+  );
+
+  // RGB output logic
+  always @(posedge clk) begin
+    if (~rst_n) begin
+      R <= 0;
+      G <= 0;
+      B <= 0;
+    end else begin
+      R <= video_active && (left_stripe || down_stripe || b_stripe) ? 2'b11 : 0;
+      G <= video_active && (right_stripe || down_stripe || a_stripe) ? 2'b11 : 0;
+      B <= video_active && (up_stripe || a_stripe || b_stripe) ? 2'b11 : 0;
+    end
+  end
+
+endmodule
+
+
+module game_controller_pmod_decoder (
+    input wire [11:0] data_reg,
+    output wire b,
+    output wire y,
+    output wire select,
+    output wire start,
+    output wire up,
+    output wire down,
+    output wire left,
+    output wire right,
+    output wire a,
+    output wire x,
+    output wire l,
+    output wire r
+);
+
+  // SNES controller mapping (12 bits):
+  assign {b, y, select, start, up, down, left, right, a, x, l, r} = data_reg;
+
+endmodule
+
+
+module game_controller_pmod_driver #(
+    parameter BIT_WIDTH = 12
+) (
+    input wire rst_n,
+    input wire clk,
+    input wire pmod_data,
+    input wire pmod_clk,
+    input wire pmod_latch,
+    output reg [BIT_WIDTH-1:0] data_reg
+);
+
+  reg pmod_clk_prev;
+  reg pmod_latch_prev;
+  reg [BIT_WIDTH-1:0] shift_reg;
+
+  // sync pmod signals to the clk domain:
+  reg [1:0] pmod_data_sync;
+  reg [1:0] pmod_clk_sync;
+  reg [1:0] pmod_latch_sync;
+
+  always @(posedge clk) begin
+    if (~rst_n) begin
+      pmod_data_sync  <= 2'b0;
+      pmod_clk_sync   <= 2'b0;
+      pmod_latch_sync <= 2'b0;
+    end else begin
+      pmod_data_sync  <= {pmod_data_sync[0], pmod_data};
+      pmod_clk_sync   <= {pmod_clk_sync[0], pmod_clk};
+      pmod_latch_sync <= {pmod_latch_sync[0], pmod_latch};
+    end
+  end
+
+  // shift register for the pmod data
+  always @(posedge clk) begin
+    if (~rst_n) begin
+      shift_reg <= 0;
+      data_reg <= 0;
+      pmod_clk_prev <= 1'b0;
+      pmod_latch_prev <= 1'b0;
+    end
+    begin
+      pmod_clk_prev   <= pmod_clk_sync[1];
+      pmod_latch_prev <= pmod_latch_sync[1];
+
+      if (pmod_latch_prev & ~pmod_latch_sync[1]) begin
+        data_reg <= shift_reg;
+      end
+      if (pmod_clk_prev & ~pmod_clk_sync[1]) begin
+        shift_reg <= {shift_reg[BIT_WIDTH-2:0], pmod_data_sync[1]};
+      end
+    end
+  end
+
+endmodule

--- a/src/examples/gaming/project.v
+++ b/src/examples/gaming/project.v
@@ -7,10 +7,10 @@
 
 `default_nettype none
 
-module tt_um_gaming_pmod_demo #(
-  parameter UI_IN_INDEX_LATCH = 3,
-  parameter UI_IN_INDEX_CLOCK = 4,
-  parameter UI_IN_INDEX_DATA  = 5
+module tt_um_vga_example #(
+  parameter UI_IN_INDEX_LATCH = 4,
+  parameter UI_IN_INDEX_CLOCK = 5,
+  parameter UI_IN_INDEX_DATA  = 6
 ) (
   input  wire [7:0] ui_in,    // Dedicated inputs
   output wire [7:0] uo_out,   // Dedicated outputs

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -6,5 +6,6 @@ import { conway } from './conway';
 import { checkers } from './checkers';
 import { drop } from './drop';
 import { music } from './music';
+import { gaming } from './gaming';
 
-export const examples: Project[] = [music, stripes, balls, logo, conway, checkers, drop];
+export const examples: Project[] = [music, stripes, balls, logo, conway, checkers, drop, gaming];

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,19 @@ import { AudioPlayer } from './AudioPlayer';
 
 let currentProject = structuredClone(examples[0]);
 
-const inputButtons = Array.from(document.querySelectorAll('#input-values button'));
-const audioButtonIndex = inputButtons.findIndex(e => e.innerHTML === "Audio");
-
+const inputButtons = Array.from(
+  document.querySelectorAll<HTMLButtonElement>('#input-values button')
+);
+const audioButtonIndex = inputButtons.findIndex((e) => e.dataset.role === 'audio');
+const gamingButtonIndex = inputButtons.findIndex((e) => e.dataset.role === 'gaming');
+let enableGamingPmod = false;
+let gamingPmodValue = 0;
+const gamingPmodInputMask = 0b01110000;
+const gamingPmodInputPins = [4, 5, 6];
+const gamingPmodInputDiv = document.getElementById('gaming-pmod-inputs');
+const gamingPmodInputButtons = Array.from(
+  document.querySelectorAll<HTMLButtonElement>('#gaming-pmod-inputs button')
+);
 
 const codeEditorDiv = document.getElementById('code-editor');
 const editor = monaco.editor.create(codeEditorDiv!, {
@@ -35,9 +45,9 @@ let jmod = new HDLModuleWASM(res.output.modules['TOP'], res.output.modules['@CON
 //let jmod = new HDLModuleJS(res.output.modules['TOP'], res.output.modules['@CONST-POOL@']);
 await jmod.init();
 
-const uo_out_offset_in_jmod_databuf = jmod.globals.lookup("uo_out").offset;
-const uio_out_offset_in_jmod_databuf = jmod.globals.lookup("uio_out").offset;
-const uio_oe_offset_in_jmod_databuf = jmod.globals.lookup("uio_oe").offset;
+const uo_out_offset_in_jmod_databuf = jmod.globals.lookup('uo_out').offset;
+const uio_out_offset_in_jmod_databuf = jmod.globals.lookup('uio_out').offset;
+const uio_oe_offset_in_jmod_databuf = jmod.globals.lookup('uio_oe').offset;
 
 function reset() {
   const ui_in = jmod.state.ui_in;
@@ -75,10 +85,8 @@ function getAudioSignal() {
 const expectedFPS = 60;
 const sampleRate = 192_000; // 192 kHz -- higher number gives a better quality
 const audioPlayer = new AudioPlayer(sampleRate, expectedFPS, () => {
-  if (audioPlayer.isRunning())
-    inputButtons[audioButtonIndex].classList.add('active');
-  else
-    inputButtons[audioButtonIndex].classList.remove('active');
+  if (audioPlayer.isRunning()) inputButtons[audioButtonIndex].classList.add('active');
+  else inputButtons[audioButtonIndex].classList.remove('active');
 });
 let enableAudioUpdate = audioPlayer.needsFeeding();
 
@@ -86,7 +94,7 @@ const vgaClockRate = 25_175_000; // 25.175 MHz -- VGA pixel clock
 const ticksPerSample = vgaClockRate / sampleRate;
 
 const lowPassFrequency = 20_000; // 20 kHz -- Audio PMOD low pass filter
-const lowPassFilterSize = Math.ceil(sampleRate/lowPassFrequency);
+const lowPassFilterSize = Math.ceil(sampleRate / lowPassFrequency);
 
 let audioTickCounter = 0;
 let audioSample = 0;
@@ -95,24 +103,35 @@ let sampleQueueForLowPassFiter = new Float32Array(lowPassFilterSize);
 let sampleQueueIndex = 0;
 
 function updateAudio() {
-  if (!enableAudioUpdate)
-    return;
+  if (!enableAudioUpdate) return;
 
   audioSample += getAudioSignal();
-  if (++audioTickCounter < ticksPerSample)
-    return;
+  if (++audioTickCounter < ticksPerSample) return;
 
   const newSample = audioSample / ticksPerSample;
 
   sampleQueueForLowPassFiter[sampleQueueIndex++] = newSample;
   sampleQueueIndex %= lowPassFilterSize;
   let filteredSample = sampleQueueForLowPassFiter[0];
-  for (let i = 1; i < lowPassFilterSize; i++)
-    filteredSample += sampleQueueForLowPassFiter[i];
+  for (let i = 1; i < lowPassFilterSize; i++) filteredSample += sampleQueueForLowPassFiter[i];
 
   audioPlayer.feed(filteredSample / lowPassFilterSize, fpsCounter.getFPS());
   audioTickCounter = 0;
   audioSample = 0;
+}
+
+let gamingPmodCounter = 0;
+function updateGamingPmod() {
+  if (!enableGamingPmod) return;
+  const cycle = gamingPmodCounter++ % 400;
+  const dataReg = gamingPmodValue << 12; // the lower 12 bits are for a second game controller
+  const pulses = 24;
+  const clock = cycle < pulses * 2 ? cycle % 2 : 0;
+  const dataIndex = cycle < pulses * 2 ? (cycle - 2) >> 1 : 0;
+  const data = (dataReg >> dataIndex) & 1;
+  const latch = cycle === pulses * 2 + 1 ? 1 : 0;
+  const gamingPmodPins = (data << 6) | (clock << 5) | (latch << 4);
+  jmod.state.ui_in = (jmod.state.ui_in & ~gamingPmodInputMask) | gamingPmodPins;
 }
 
 let stopped = false;
@@ -147,8 +166,7 @@ editor.onDidChangeModelContent(async () => {
     jmod.dispose();
   }
   inputButtons.map((b) => b.classList.remove('active'));
-  if (audioPlayer.isRunning())
-    inputButtons[audioButtonIndex].classList.add('active');
+  if (audioPlayer.isRunning()) inputButtons[audioButtonIndex].classList.add('active');
   jmod = new HDLModuleWASM(res.output.modules['TOP'], res.output.modules['@CONST-POOL@']);
   await jmod.init();
   reset();
@@ -181,7 +199,7 @@ function animationFrame(now: number) {
   }
 
   if (audioLatencyDisplay) {
-    audioLatencyDisplay.textContent = `${audioPlayer.latencyInMilliseconds.toFixed(0)}`
+    audioLatencyDisplay.textContent = `${audioPlayer.latencyInMilliseconds.toFixed(0)}`;
   }
 
   if (stopped || !imageData || !ctx) {
@@ -192,6 +210,7 @@ function animationFrame(now: number) {
   const data = new Uint8Array(imageData.data.buffer);
   frameLoop: for (let y = 0; y < 520; y++) {
     waitFor(() => !getVGASignals().hsync);
+    updateGamingPmod();
     for (let x = 0; x < 736; x++) {
       const offset = (y * 736 + x) * 4;
       jmod.tick2(1);
@@ -247,10 +266,21 @@ document.querySelector('#download-button')?.addEventListener('click', () => {
 
 function toggleButton(index: number) {
   if (index === audioButtonIndex) {
-    if (audioPlayer.isRunning())
-      audioPlayer.suspend();
-    else
-      audioPlayer.resume();
+    if (audioPlayer.isRunning()) audioPlayer.suspend();
+    else audioPlayer.resume();
+    return;
+  }
+  if (index === gamingButtonIndex) {
+    enableGamingPmod = !enableGamingPmod;
+    if (enableGamingPmod) {
+      inputButtons[gamingButtonIndex].classList.add('active');
+    } else {
+      inputButtons[gamingButtonIndex].classList.remove('active');
+    }
+    for (const pin of gamingPmodInputPins) {
+      inputButtons[pin].disabled = enableGamingPmod;
+    }
+    gamingPmodInputDiv!.style.display = enableGamingPmod ? 'block' : 'none';
     return;
   }
   const bit = 1 << index;
@@ -273,4 +303,18 @@ document.addEventListener('keydown', (e) => {
 
 inputButtons.forEach((button, index) => {
   button.addEventListener('click', () => toggleButton(index));
+});
+
+gamingPmodInputButtons.forEach((button) => {
+  const index = parseInt(button.dataset.index!, 10);
+  const mouseDown = () => {
+    gamingPmodValue = gamingPmodValue | (1 << index);
+  };
+  const mouseUp = () => {
+    gamingPmodValue = gamingPmodValue & ~(1 << index);
+  };
+  button.addEventListener('mousedown', mouseDown);
+  button.addEventListener('pointerdown', mouseDown);
+  button.addEventListener('mouseup', mouseUp);
+  button.addEventListener('pointerup', mouseUp);
 });


### PR DESCRIPTION
Couldn't locate the VGA PMOD that I'm pretty certain I have, so I did this semi-blind, just using a scope, but the output is sensible and reacts to button presses as expected.

I have:

  * made various fixes;
  * isolated the `gaming_pmod` verilog from the sample project, so that it's reusable;
  * changed things to support 2 controllers, have an is_present field to indicate detection, and leverage the 2-bit colours in the sample to actually show the state of both controllers with the bars;
  * commented the module code to assist anyone actually using it

Also of note, something that cause quite a bit of putzing around, was we agreed on pins 4,5,6 but [my snespmod docs](https://github.com/psychogenic/snespmod?tab=readme-ov-file#default-tt-configuration) are using PMOD indexing, and refer to ui_in[5:3], but this driver used ui_in[6:4].  I've left that, but need confirmation (and to edit) the CH32V lib accordingly.
