### PR TITLE
fix(examples): fix reset in stripes & checkers

### DIFF
--- a/src/examples/checkers/project.v
+++ b/src/examples/checkers/project.v
@@ -18,7 +18,7 @@ module tt_um_vga_example(
 );
   // increase couner every frame (vsync happens once per frame)
   reg [9:0] counter;
-  always @(posedge vsync) begin
+  always @(posedge vsync, negedge rst_n) begin
     if (~rst_n) begin
       counter <= 0;
     end else begin

--- a/src/examples/stripes/project.v
+++ b/src/examples/stripes/project.v
@@ -55,7 +55,7 @@ module tt_um_vga_example(
   assign G = video_active ? {moving_x[6], pix_y[2]} : 2'b00;
   assign B = video_active ? {moving_x[7], pix_y[5]} : 2'b00;
   
-  always @(posedge vsync) begin
+  always @(posedge vsync, negedge rst_n) begin
     if (~rst_n) begin
       counter <= 0;
     end else begin


### PR DESCRIPTION
`@(posedge vsync)` doesn't happen while in reset, so the `if (~rst_n)` branch is never active