### PR TITLE
feat: allow branch of project to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ Available presets: `stripes`, `music`, `rings`, `logo`, `conway`, `checkers`, `d
     https://vga-playground.com/?repo=https://github.com/urish/tt-rings
 
 This fetches `info.yaml` from the repository to discover source files, then loads them into the editor. The repository must follow the [Tiny Tapeout](https://tinytapeout.com/) project structure.
+
+Optionally, you can load a specific branch. If this is not specified, or that branch is not found, defaults to `main` then `master`.
+
+    https://vga-playground.com/?repo=https://github.com/urish/tt-rings&branch=ttihp0p4

--- a/src/github/loadProject.ts
+++ b/src/github/loadProject.ts
@@ -101,16 +101,20 @@ async function tryFetchFiles(
   return entries.filter((e): e is [string, string] => e != null);
 }
 
-export async function loadProjectFromRepo(repoUrl: string): Promise<Project> {
+export async function loadProjectFromRepo(
+  repoUrl: string,
+  branchName: string | null,
+): Promise<Project> {
   const { owner, repo } = parseRepoUrl(repoUrl);
 
   // Start loading YAML parser in parallel with the fetch
   const yamlModulePromise = import('yaml');
 
-  // Try main branch first, fall back to master
+  // Try given branch first, then fall back to main branch then master
+  const branchOptions = [...(branchName !== null ? [branchName] : []), 'main', 'master'];
   let infoYaml: string | null = null;
   let branch = 'main';
-  for (const b of ['main', 'master']) {
+  for (const b of branchOptions) {
     const url = githubRawUrl(owner, repo, b, 'info.yaml');
     const res = await fetch(url);
     if (res.ok) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ let currentProject = structuredClone(examples[0]);
 
 const params = new URLSearchParams(window.location.search);
 const repoParam = params.get('repo');
+const branchParam = params.get('branch');
 const presetParam = params.get('preset');
 
 const codeEditorDiv = document.getElementById('code-editor')!;
@@ -39,7 +40,8 @@ let repoError = '';
 if (repoParam) {
   codeEditorDiv.textContent = 'Loading project from GitHub...';
   try {
-    currentProject = await loadProjectFromRepo(repoParam);
+    console.log(branchParam);
+    currentProject = await loadProjectFromRepo(repoParam, branchParam);
   } catch (e) {
     console.error('Failed to load project from URL:', e);
     repoError = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
Added a search parameter in the URL to load a specific branch instead of only `main`/`master`. If the `branch` search parameter is not specified or is not found in the repo, will default to `main`/`master`. Also updated the README with a brief (and admittedly not very apparent) example.